### PR TITLE
[emulator] replace bzero with std::memset

### DIFF
--- a/emulator/emulator.cpp
+++ b/emulator/emulator.cpp
@@ -4,6 +4,7 @@
 #include <mos6502.h>
 #include <stdexcept>
 #include <string>
+#include <cstring>
 #include <strings.h>
 
 // g++ -Imos6502 emulator.cpp mos6502/mos6502.cpp -o emulator
@@ -46,7 +47,7 @@ int main(int argc, char** argv) {
 			std::cerr << "cannot read the program from " << program_path << '\n'; // Can happen if the file is too short
 		}
 	}
-	::bzero(ram.data(), ram.size());
+	std::memset(ram.data(), 0, ram.size());
 
 	// Run the program
 	mos6502 emulator;


### PR DESCRIPTION
`bzero` as a function to fill a memory area with zeroes is apparently not part of the C++ standard, but a POSIX feature, and so the emulator fails to compile for Windows under MSYS2. Simply using `std::memset` instead (defined in `cstring`) can accomplish the same thing and should work everywhere, since it is part of the standard.